### PR TITLE
Allow config by string

### DIFF
--- a/include/libkahypar.h
+++ b/include/libkahypar.h
@@ -60,6 +60,8 @@ KAHYPAR_API kahypar_context_t* kahypar_context_new();
 KAHYPAR_API void kahypar_context_free(kahypar_context_t* kahypar_context);
 KAHYPAR_API void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                                                      const char* ini_file_name);
+KAHYPAR_API void kahypar_configure_context_from_string(kahypar_context_t* kahypar_context,
+                                                     const char* ini_string);
 
 KAHYPAR_API void kahypar_set_seed(kahypar_context_t* kahypar_context, const int seed);
 KAHYPAR_API void kahypar_supress_output(kahypar_context_t* kahypar_context, const bool decision);

--- a/kahypar/application/command_line_options.h
+++ b/kahypar/application/command_line_options.h
@@ -729,13 +729,7 @@ void processCommandLineInput(Context& context, int argc, char* argv[]) {
   }
 }
 
-
-void parseIniToContext(Context& context, const std::string& ini_filename) {
-  std::ifstream file(ini_filename.c_str());
-  if (!file) {
-    std::cerr << "Could not load context file at: " << ini_filename << std::endl;
-    std::exit(-1);
-  }
+void parseToContext(Context& context, std::istream& ini_stream) {
   const int num_columns = 80;
 
   po::variables_map cmd_vm;
@@ -748,11 +742,26 @@ void parseIniToContext(Context& context, const std::string& ini_filename) {
   .add(createRefinementOptionsDescription(context, num_columns, false))
   .add(createEvolutionaryOptionsDescription(context, num_columns));
 
-  po::store(po::parse_config_file(file, ini_line_options, true), cmd_vm);
+  po::store(po::parse_config_file(ini_stream, ini_line_options, true), cmd_vm);
   po::notify(cmd_vm);
 
   if (context.partition.use_individual_part_weights) {  // Note(Lars): This affects flow network sizes!
     context.partition.epsilon = 0;
   }
+}
+
+void parseStringToContext(Context& context, const std::string& ini_string) {
+  std::istringstream stream(ini_string);
+  parseToContext(context, stream);
+}
+
+void parseIniToContext(Context& context, const std::string& ini_filename) {
+  std::ifstream file(ini_filename.c_str());
+  if (!file) {
+    std::cerr << "Could not load context file at: " << ini_filename << std::endl;
+    std::exit(-1);
+  }
+  
+  parseToContext(context, file);
 }
 }  // namespace kahypar

--- a/lib/libkahypar.cc
+++ b/lib/libkahypar.cc
@@ -76,6 +76,12 @@ void kahypar_configure_context_from_file(kahypar_context_t* kahypar_context,
                              ini_file_name);
 }
 
+void kahypar_configure_context_from_string(kahypar_context_t* kahypar_context,
+                                           const char* ini_string) {
+  kahypar::parseStringToContext(*reinterpret_cast<kahypar::Context*>(kahypar_context),
+                             ini_string);
+}
+
 void kahypar_set_fixed_vertices(kahypar_hypergraph_t* kahypar_hypergraph,
                                 const kahypar_partition_id_t* fixed_vertex_blocks) {
   kahypar::Hypergraph& hypergraph = *reinterpret_cast<kahypar::Hypergraph*>(kahypar_hypergraph);


### PR DESCRIPTION
Allows to configure the KaHyPar context by a string (with the same content as an INI file).